### PR TITLE
BungeeCord logger fix

### DIFF
--- a/simplixcore-common/simplixcore-common-api/src/main/java/dev/simplix/core/common/inject/SimplixInstaller.java
+++ b/simplixcore-common/simplixcore-common-api/src/main/java/dev/simplix/core/common/inject/SimplixInstaller.java
@@ -64,10 +64,6 @@ public class SimplixInstaller {
     this.log = logger;
   }
 
-  public static SimplixInstaller newInstance(org.slf4j.Logger logger) {
-    return new SimplixInstaller(logger);
-  }
-
   public static void init(org.slf4j.Logger logger) {
     if (INSTANCE == null) {
       INSTANCE = new SimplixInstaller(logger);

--- a/simplixcore-common/simplixcore-common-api/src/main/java/dev/simplix/core/common/inject/SimplixInstaller.java
+++ b/simplixcore-common/simplixcore-common-api/src/main/java/dev/simplix/core/common/inject/SimplixInstaller.java
@@ -32,7 +32,6 @@ import lombok.AllArgsConstructor;
 import lombok.Cleanup;
 import lombok.NonNull;
 import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.Nullable;
 import org.reflections.Reflections;
 
@@ -41,11 +40,10 @@ import org.reflections.Reflections;
  * A {@link SimplixApplication} needs to be registered using {@link SimplixInstaller#register(Class,
  * Module...)} in order to use dependency injection in your software project.
  */
-@Slf4j
 public class SimplixInstaller {
 
   private static final String SIMPLIX_BOOTSTRAP = "[Simplix | Bootstrap] ";
-  private static final SimplixInstaller INSTANCE = new SimplixInstaller();
+  private static SimplixInstaller INSTANCE = null;
   private final Map<Class<?>, Injector> injectorMap = new HashMap<>();
   private final Map<Class<?>, DependencyManifest> dependenciesMap = new HashMap<>();
 
@@ -60,8 +58,26 @@ public class SimplixInstaller {
   private DependencyLoader dependencyLoader;
   private LibraryLoader libraryLoader;
   private Updater updater;
+  private final org.slf4j.Logger log;
+
+  public SimplixInstaller(org.slf4j.Logger logger) {
+    this.log = logger;
+  }
+
+  public static SimplixInstaller newInstance(org.slf4j.Logger logger) {
+    return new SimplixInstaller(logger);
+  }
+
+  public static void init(org.slf4j.Logger logger) {
+    if (INSTANCE == null) {
+      INSTANCE = new SimplixInstaller(logger);
+    }
+  }
 
   public static SimplixInstaller instance() {
+    if (INSTANCE == null) {
+      throw new IllegalStateException("Instance not yet set");
+    }
     return INSTANCE;
   }
 
@@ -591,7 +607,6 @@ public class SimplixInstaller {
       @NonNull InstallationContext context) {
     for (Class<?> componentClass : context.reflections.getTypesAnnotatedWith(Component.class)) {
       try {
-
         AbstractSimplixModule simplixModule;
         Component component;
         try {

--- a/simplixcore-common/simplixcore-common-api/src/main/java/dev/simplix/core/common/inject/SimplixInstaller.java
+++ b/simplixcore-common/simplixcore-common-api/src/main/java/dev/simplix/core/common/inject/SimplixInstaller.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.lang.reflect.Constructor;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -28,10 +29,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.logging.Logger;
-import lombok.AllArgsConstructor;
-import lombok.Cleanup;
-import lombok.NonNull;
-import lombok.SneakyThrows;
+import lombok.*;
 import org.jetbrains.annotations.Nullable;
 import org.reflections.Reflections;
 
@@ -239,7 +237,8 @@ public class SimplixInstaller {
           "dev.simplix.core.common.libloader.SimpleLibraryLoader");
 
       Class<?> clazz = Class.forName(libLoaderClass);
-      this.libraryLoader = (LibraryLoader) clazz.newInstance();
+      final Constructor<?> constructor = clazz.getConstructor(org.slf4j.Logger.class);
+      this.libraryLoader = (LibraryLoader) constructor.newInstance(log);
     } catch (Exception exception) {
       throw new RuntimeException("Unable to initialize library loader", exception);
     }

--- a/simplixcore-common/simplixcore-common-implementation/src/main/java/dev/simplix/core/common/libloader/SimpleLibraryLoader.java
+++ b/simplixcore-common/simplixcore-common-implementation/src/main/java/dev/simplix/core/common/libloader/SimpleLibraryLoader.java
@@ -17,16 +17,16 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Function;
 import lombok.NonNull;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
 
-@Slf4j
 public class SimpleLibraryLoader implements LibraryLoader {
 
+  private final Logger log;
   private final Gson gson = new GsonBuilder().create();
   private final Set<File> files = new HashSet<>();
   private Method addMethod;
-
-  {
+  public SimpleLibraryLoader(@NonNull Logger log) {
+    this.log = log;
     try {
       addMethod = URLClassLoader.class.getDeclaredMethod("addURL", URL.class);
       addMethod.setAccessible(true);

--- a/simplixcore-common/simplixcore-common-tests/src/test/java/dev/simplix/core/common/inject/SimplixInstallerTest.java
+++ b/simplixcore-common/simplixcore-common-tests/src/test/java/dev/simplix/core/common/inject/SimplixInstallerTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 
 @SimplixApplication(name = "TestApplication", version = "1.0.0-SNAPSHOT", authors = "SimplixSoftworks")
 class SimplixInstallerTest {
@@ -17,6 +18,8 @@ class SimplixInstallerTest {
   @Test
   @BeforeAll
   static void instance() {
+    SimplixInstaller.init(LoggerFactory.getLogger(SimplixInstaller.class));
+
     Assertions.assertNotNull(
         SimplixInstaller.instance(),
         "SimplixInstaller instance mustn't be null");

--- a/simplixcore-minecraft/simplixcore-minecraft-bungeecord/simplixcore-minecraft-bungeecord-plugin/pom.xml
+++ b/simplixcore-minecraft/simplixcore-minecraft-bungeecord/simplixcore-minecraft-bungeecord-plugin/pom.xml
@@ -22,11 +22,6 @@
   <dependencies>
     <!-- Simple logging facade for java -->
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>1.7.30</version>
-    </dependency>
-    <dependency>
       <groupId>dev.simplix.core</groupId>
       <artifactId>simplixcore-minecraft-bungeecord-slf4j</artifactId>
       <version>1.0.0-SNAPSHOT</version>

--- a/simplixcore-minecraft/simplixcore-minecraft-bungeecord/simplixcore-minecraft-bungeecord-plugin/src/main/java/dev/simplix/core/minecraft/bungeecord/plugin/SimplixPlugin.java
+++ b/simplixcore-minecraft/simplixcore-minecraft-bungeecord/simplixcore-minecraft-bungeecord-plugin/src/main/java/dev/simplix/core/minecraft/bungeecord/plugin/SimplixPlugin.java
@@ -7,6 +7,7 @@ import dev.simplix.core.common.inject.SimplixInstaller;
 import dev.simplix.core.common.platform.Platform;
 import dev.simplix.core.minecraft.bungeecord.plugin.deploader.PluginTypeHandler;
 import dev.simplix.core.minecraft.bungeecord.plugin.listeners.ApplicationPreInstallListener;
+import dev.simplix.slf4j.impl.JDK14LoggerAdapter;
 import java.io.File;
 import java.util.logging.Level;
 import net.md_5.bungee.api.ProxyServer;
@@ -19,6 +20,7 @@ public final class SimplixPlugin extends Plugin {
 
   @Override
   public void onLoad() {
+    SimplixInstaller.init(new JDK14LoggerAdapter(ProxyServer.getInstance().getLogger()));
     new ApplicationPreInstallListener();
     try {
       SimplixInstaller.instance().updater().installCachedUpdates();

--- a/simplixcore-minecraft/simplixcore-minecraft-bungeecord/simplixcore-minecraft-bungeecord-plugin/src/main/java/dev/simplix/core/minecraft/bungeecord/plugin/SimplixPlugin.java
+++ b/simplixcore-minecraft/simplixcore-minecraft-bungeecord/simplixcore-minecraft-bungeecord-plugin/src/main/java/dev/simplix/core/minecraft/bungeecord/plugin/SimplixPlugin.java
@@ -20,7 +20,8 @@ public final class SimplixPlugin extends Plugin {
 
   @Override
   public void onLoad() {
-    SimplixInstaller.init(new JDK14LoggerAdapter(ProxyServer.getInstance().getLogger()));
+    final JDK14LoggerAdapter logger = new JDK14LoggerAdapter(ProxyServer.getInstance().getLogger());
+    SimplixInstaller.init(logger);
     new ApplicationPreInstallListener();
     try {
       SimplixInstaller.instance().updater().installCachedUpdates();
@@ -33,7 +34,7 @@ public final class SimplixPlugin extends Plugin {
     System.setProperty(
         "dev.simplix.core.libloader.ClassLoaderFabricator",
         "dev.simplix.core.minecraft.bungeecord.plugin.libloader.PluginClassLoaderFabricator");
-    ArtifactDependencyLoader.registerTypeHandler("plugin", new PluginTypeHandler());
+    ArtifactDependencyLoader.registerTypeHandler("plugin", new PluginTypeHandler(logger));
     SimplixInstaller.instance().libraryLoader().loadLibraries(new File("libraries"));
   }
 

--- a/simplixcore-minecraft/simplixcore-minecraft-bungeecord/simplixcore-minecraft-bungeecord-plugin/src/main/java/dev/simplix/core/minecraft/bungeecord/plugin/SimplixPlugin.java
+++ b/simplixcore-minecraft/simplixcore-minecraft-bungeecord/simplixcore-minecraft-bungeecord-plugin/src/main/java/dev/simplix/core/minecraft/bungeecord/plugin/SimplixPlugin.java
@@ -12,6 +12,7 @@ import java.io.File;
 import java.util.logging.Level;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.plugin.Plugin;
+import org.reflections.Reflections;
 
 @SimplixApplication(name = "SimplixCore", authors = "Simplix Softworks",
     workingDirectory = "plugins/SimplixCore")
@@ -22,6 +23,7 @@ public final class SimplixPlugin extends Plugin {
   public void onLoad() {
     final JDK14LoggerAdapter logger = new JDK14LoggerAdapter(ProxyServer.getInstance().getLogger());
     SimplixInstaller.init(logger);
+    Reflections.log = logger;
     new ApplicationPreInstallListener();
     try {
       SimplixInstaller.instance().updater().installCachedUpdates();

--- a/simplixcore-minecraft/simplixcore-minecraft-bungeecord/simplixcore-minecraft-bungeecord-plugin/src/main/java/dev/simplix/core/minecraft/bungeecord/plugin/deploader/PluginTypeHandler.java
+++ b/simplixcore-minecraft/simplixcore-minecraft-bungeecord/simplixcore-minecraft-bungeecord-plugin/src/main/java/dev/simplix/core/minecraft/bungeecord/plugin/deploader/PluginTypeHandler.java
@@ -12,18 +12,20 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Stack;
 import java.util.concurrent.atomic.AtomicReference;
-import lombok.extern.slf4j.Slf4j;
+import lombok.NonNull;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.plugin.PluginDescription;
 import net.md_5.bungee.api.plugin.PluginManager;
+import org.slf4j.Logger;
 
-@Slf4j
 public class PluginTypeHandler implements DependencyTypeHandler {
 
+  private final Logger log;
   private Field toLoadField;
   private Method enable;
 
-  public PluginTypeHandler() {
+  public PluginTypeHandler(@NonNull Logger log) {
+    this.log = log;
     try {
       toLoadField = PluginManager.class.getDeclaredField("toLoad");
       toLoadField.setAccessible(true);

--- a/simplixcore-minecraft/simplixcore-minecraft-bungeecord/simplixcore-minecraft-bungeecord-slf4j/src/main/java/dev/simplix/core/minecraft/bungeecord/slf4j/BungeeLoggerFactory.java
+++ b/simplixcore-minecraft/simplixcore-minecraft-bungeecord/simplixcore-minecraft-bungeecord-slf4j/src/main/java/dev/simplix/core/minecraft/bungeecord/slf4j/BungeeLoggerFactory.java
@@ -5,7 +5,7 @@ import lombok.NonNull;
 import net.md_5.bungee.api.ProxyServer;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.Logger;
-import org.slf4j.impl.JDK14LoggerAdapter;
+import dev.simplix.slf4j.impl.JDK14LoggerAdapter;
 
 public final class BungeeLoggerFactory implements ILoggerFactory {
 

--- a/simplixcore-minecraft/simplixcore-minecraft-bungeecord/simplixcore-minecraft-bungeecord-slf4j/src/main/java/dev/simplix/slf4j/impl/JDK14LoggerAdapter.java
+++ b/simplixcore-minecraft/simplixcore-minecraft-bungeecord/simplixcore-minecraft-bungeecord-slf4j/src/main/java/dev/simplix/slf4j/impl/JDK14LoggerAdapter.java
@@ -17,7 +17,7 @@
  * OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-package org.slf4j.impl;
+package dev.simplix.slf4j.impl;
 
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -46,7 +46,7 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
 
   // WARN: JDK14LoggerAdapter constructor should have only package access so
   // that only JDK14LoggerFactory be able to create one.
-  JDK14LoggerAdapter(java.util.logging.Logger logger) {
+  public JDK14LoggerAdapter(java.util.logging.Logger logger) {
     this.logger = logger;
     this.name = logger.getName();
   }

--- a/simplixcore-minecraft/simplixcore-minecraft-bungeecord/simplixcore-minecraft-bungeecord-slf4j/src/main/java/dev/simplix/slf4j/impl/StaticLoggerBinder.java
+++ b/simplixcore-minecraft/simplixcore-minecraft-bungeecord/simplixcore-minecraft-bungeecord-slf4j/src/main/java/dev/simplix/slf4j/impl/StaticLoggerBinder.java
@@ -38,7 +38,7 @@
  * OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-package org.slf4j.impl;
+package dev.simplix.slf4j.impl;
 
 import dev.simplix.core.minecraft.bungeecord.slf4j.BungeeLoggerFactory;
 import net.md_5.bungee.api.ProxyServer;

--- a/simplixcore-minecraft/simplixcore-minecraft-spigot/simplixcore-minecraft-spigot-plugin/src/main/java/dev/simplix/core/minecraft/spigot/plugin/SimplixPlugin.java
+++ b/simplixcore-minecraft/simplixcore-minecraft-spigot/simplixcore-minecraft-spigot-plugin/src/main/java/dev/simplix/core/minecraft/spigot/plugin/SimplixPlugin.java
@@ -18,6 +18,7 @@ import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.plugin.java.JavaPluginLoader;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.LoggerFactory;
 
 @SimplixApplication(name = "SimplixCore", authors = "Simplix Softworks",
     workingDirectory = "plugins/SimplixCore")
@@ -38,6 +39,7 @@ public final class SimplixPlugin extends JavaPlugin {
 
   @Override
   public void onLoad() {
+    SimplixInstaller.init(LoggerFactory.getLogger(SimplixInstaller.class));
     new ApplicationPreInstallListener();
     try {
       SimplixInstaller.instance().updater().installCachedUpdates();

--- a/simplixcore-minecraft/simplixcore-minecraft-spigot/simplixcore-minecraft-spigot-plugin/src/main/java/dev/simplix/core/minecraft/spigot/plugin/deploader/PluginTypeHandler.java
+++ b/simplixcore-minecraft/simplixcore-minecraft-spigot/simplixcore-minecraft-spigot-plugin/src/main/java/dev/simplix/core/minecraft/spigot/plugin/deploader/PluginTypeHandler.java
@@ -39,7 +39,7 @@ public class PluginTypeHandler implements DependencyTypeHandler {
       log.warn("[Simplix | DependencyLoader] "
                + dependency.applicationName()
                + ": Version conflict of plugin "
-               + dependency.toString());
+               + dependency);
       log.warn("[Simplix | DependencyLoader] "
                + dependency.applicationName()
                + ": This file seems to contain another version of this dependency: "

--- a/simplixcore-minecraft/simplixcore-minecraft-spigot/simplixcore-minecraft-spigot-tests/src/test/java/dev/simplix/core/minecraft/spigot/tests/GuiceSpigotTest.java
+++ b/simplixcore-minecraft/simplixcore-minecraft-spigot/simplixcore-minecraft-spigot-tests/src/test/java/dev/simplix/core/minecraft/spigot/tests/GuiceSpigotTest.java
@@ -20,6 +20,7 @@ import lombok.NoArgsConstructor;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 
 public class GuiceSpigotTest {
 
@@ -28,7 +29,7 @@ public class GuiceSpigotTest {
   @BeforeAll
   static void setUp() {
     // We need a new instance of the SimplixInstaller since it might already be installed by the plugin test
-    SIMPLIX_INSTALLER = new SimplixInstaller();
+    SIMPLIX_INSTALLER = new SimplixInstaller(LoggerFactory.getLogger(SimplixInstaller.class));
     if (!MockBukkit.isMocked()) {
       MockBukkit.mock();
     }

--- a/simplixcore-minecraft/simplixcore-minecraft-velocity/simplixcore-minecraft-velocity-plugin/src/main/java/dev/simplix/core/minecraft/velocity/plugin/SimplixPlugin.java
+++ b/simplixcore-minecraft/simplixcore-minecraft-velocity/simplixcore-minecraft-velocity-plugin/src/main/java/dev/simplix/core/minecraft/velocity/plugin/SimplixPlugin.java
@@ -30,6 +30,7 @@ public class SimplixPlugin {
       @NonNull ProxyServer proxyServer) {
     this.proxyServer = proxyServer;
     this.logger = logger;
+    SimplixInstaller.init(logger);
     new ApplicationPreInstallListener(proxyServer);
     try {
       SimplixInstaller.instance().updater().installCachedUpdates();


### PR DESCRIPTION
The slf4j implementation of BungeeCord is currently faulty. 
See https://github.com/SpigotMC/BungeeCord/issues/3084

This PR enforces the usage of our own JDK14LoggerAdapter in SimplixCore to enable proper logging.